### PR TITLE
Fix ebay filter rule (#71)

### DIFF
--- a/obtrusive.txt
+++ b/obtrusive.txt
@@ -229,7 +229,6 @@ dutchnews.nl##.cookiepolicy
 e4.com###cookieNotification
 e4.com###gn-cookie-accept
 eadt.co.uk###cookielaw2
-ebay.de##.gh-banner-active
 ebuyer.com###cookieContainer
 economist.com###ec-cookie-messages-container
 edbpriser.dk###cookieInformerBooklet
@@ -769,7 +768,6 @@ cdn.iubenda.com/cookie_solution/iubenda_cs.js
 ###cookiesPop
 ###cookiestatement
 ###cookiewarning
-###gh-cookieb
 ###politicaCookies
 ###warning_cookie
 ##.alertCookie
@@ -779,7 +777,8 @@ cdn.iubenda.com/cookie_solution/iubenda_cs.js
 ##.cookie_privacy_info_bar
 ##.cookieControl
 ##.gn-cookie-alert
-##gh-cookieb-active
+! ebay.*
+##.gh-banner-active>.gh-banner-active
 !
 !--- block-the-eu-cookie-shit-list
 !--- https://github.com/r4vi/block-the-eu-cookie-shit-list


### PR DESCRIPTION
This leaves behind an ugly gray bar that fades in on page load, but probably can't be circumvented since it's CSS based.
